### PR TITLE
fix-permissions should be applied to user home?

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,6 +114,11 @@ ENV NB_USER=jovyan \
    NB_GID=100 \
    GDAL_DATA=/usr/share/gdal/2.4/
 
+ENV HOME=/home/jovyan
+ENV SHELL="bash"
+ENV PATH="$HOME/.local/bin:$PATH"
+RUN mkdir -p $HOME && chmod -R 777 $HOME
+
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/fix-permissions /usr/local/bin/fix-permissions
 RUN chmod +x /usr/local/bin/fix-permissions
 # Create user with UID=1000 and in the 'users' group
@@ -121,11 +126,6 @@ RUN chmod +x /usr/local/bin/fix-permissions
 RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER \
    && chmod g+w /etc/passwd /etc/group \
    && fix-permissions $HOME
-
-ENV HOME=/home/jovyan
-ENV SHELL="bash"
-ENV PATH="$HOME/.local/bin:$PATH"
-RUN mkdir -p $HOME && chmod -R 777 $HOME
 
 EXPOSE 9988
 


### PR DESCRIPTION
- Should fix-permissions be applied to `/home/jovyan` rather than whatever `$HOME` was before (root?)?