### PR TITLE
Add more libs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,6 +65,7 @@ RUN pip3 install \
     param \
     datashader \
     numexpr \
+    numexpr3 \
     jupyter-ui-poll \
     sidecar==0.3.0 \
     ipyevents==0.7.0 \
@@ -95,7 +96,7 @@ RUN echo "Adding jupyter lab extensions" \
 && echo "...done"
 
 RUN echo Installing more libs \
-&& pip3 install --no-cache --extra-index-url="https://packages.dea.gadevs.ga" \
+&& pip3 install --no-cache --extra-index-url="https://packages.dea.ga.gov.au" \
 datacube_stats \
 odc_ui \
 odc_index \
@@ -106,6 +107,8 @@ odc_aio \
 odc_ppt \
 odc_dscache \
 odc_dtools \
+odc_algo \
+hdstats \
 otps \
 && config_otps \
 && rm -rf $HOME/.cache/pip

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,6 +65,10 @@ RUN pip3 install \
     param \
     datashader \
     numexpr \
+    jupyter-ui-poll \
+    sidecar==0.3.0 \
+    ipyevents==0.7.0 \
+    ipycanvas==0.3.4 \
     cligj  --upgrade \
     && rm -rf $HOME/.cache/pip
 
@@ -83,6 +87,9 @@ RUN echo "Adding jupyter lab extensions" \
 && jupyter labextension install --no-build jupyterlab_bokeh@v1.0.0 \
 && jupyter labextension install --no-build nbdime-jupyterlab@v1.0.0 \
 && jupyter labextension install --no-build @ryantam626/jupyterlab_code_formatter@v0.5.0 \
+&& jupyter labextension install --no-build @jupyter-widgets/jupyterlab-sidecar@v0.4.0 \
+&& jupyter labextension install --no-build ipyevents@v1.7.0 \
+&& jupyter labextension install --no-build ipycanvas@v0.3.4 \
 && jupyter lab build \
 && jupyter labextension list \
 && echo "...done"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,6 +70,7 @@ RUN pip3 install \
     sidecar==0.3.0 \
     ipyevents==0.7.0 \
     ipycanvas==0.3.4 \
+    line_profiler \
     cligj  --upgrade \
     && rm -rf $HOME/.cache/pip
 


### PR DESCRIPTION
- `numexpr3` new version of `numexpr` (fused numpy operations)
- `jupyter-ui-poll` my library to enable interactive widgets in a long running notebook cell
- `sidecar` display map or any other interactive widget to the side of the notebook
- `ipyevents`, `ipycanvas` cool libs could be very useful for data annotations inside a notebook
- `hdstat`, `odc-algo` geomedian as a dask operation + other dask friendly ops
- `line_profiler` profile python code line-by-line, requested in `dea-notebooks` repo