### PR TITLE
Base image no longer provides nor needs docker-entrypoint.sh wrapper

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -165,7 +165,7 @@ RUN [ "${WITH_SUDO}" != "yes" ] || { adduser ${NB_USER} sudo \
 
 USER ${NB_USER}
 
-ENTRYPOINT ["/bin/tini", "-s", "--", "docker-entrypoint.sh"]
+ENTRYPOINT ["/bin/tini", "-s", "--"]
 
 CMD ["jupyter", "lab", \
 "--ip=0.0.0.0", \


### PR DESCRIPTION
Datacube now reads config directly from environment variables, so no need to
render config to file.