### PR TITLE
Add tqdm, ipyfilechooser, and upgrade xarray libs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,6 +80,9 @@ RUN pip3 install \
     tensorflow \
     tensorflow-gpu \
     cligj  --upgrade \
+    tqdm \
+    ipyfilechooser \
+    xarray  --upgrade \
     && rm -rf $HOME/.cache/pip
 
 RUN jupyter nbextension enable --py --sys-prefix ipyleaflet \


### PR DESCRIPTION
## Background
FrontierSI has been working with a team at Curtin Uni who are going to use the Sandbox in an upcoming workshop on 28th January. They’re wondering if they can have a few pip libraries added to the sandbox:
• `tqdm`
• `ipyfilechooser`
• Upgrade of `xarray` to >= `0.14.1`

## Updates in this PR
- Add `tqdm`, `ipyfilechooser` libs to docker file
- Upgrade `xarray` lib to use latest version