### PR TITLE
upgrade jupyterhub version to 1.0.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -130,7 +130,7 @@ otps \
 && rm -rf $HOME/.cache/pip
 
 # download otps data: want it separate to see image size delta
-RUN config_otps
+# RUN config_otps
 
 # Add more libs for incremental docker build here, move them to main section later
 RUN echo Installing more libs \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN pip3 install \
     jupyter==1.0.0 \
     jupyterlab==1.0.9 \
     jupyter-server-proxy==1.1.0 \
-    jupyterhub==0.9.6 \
+    jupyterhub==1.0.0 \
     ipyleaflet==0.11.1 \
     dask-labextension==1.0.3 \
     nbdime==1.1.0 \


### PR DESCRIPTION
Looking into options so that we can inject custom template using hub initContainer. This option is only available in newer developer version of jupyterhub chart (developer release). Hence upgraded jupyterhub version.

reference: https://discourse.jupyter.org/t/customizing-jupyterhub-on-kubernetes/1769 