### PR TITLE
upgade jupyterhub libs to work with hub chart release version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,8 +39,8 @@ RUN pip3 install \
     ipympl \
     jupyter==1.0.0 \
     jupyterlab==1.0.9 \
-    jupyter-server-proxy==1.1.0 \
-    jupyterhub==1.0.0 \
+    jupyter-server-proxy==1.2.0 \
+    jupyterhub==1.1.0 \
     ipyleaflet==0.11.1 \
     dask-labextension==1.0.3 \
     nbdime==1.1.0 \


### PR DESCRIPTION
upgraded jupyterhub libs version to test out newer version of chart beta release that supports auth enhancement and custom templates -  
Reference links:
https://github.com/jupyterhub/jupyterhub/issues/2860 and https://discourse.jupyter.org/t/customizing-jupyterhub-on-kubernetes/1769/18

